### PR TITLE
[FQ-98] Export Preguntas

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,3 +11,19 @@ export const scoreToColor = (score: number) => {
   if (score >= 30) return 'yellow-500';
   return 'red-600';
 };
+
+export const downloadFile = (data: string, filename: string, mimeType: string = 'text/csv;charset=utf-8;') => {
+  const blob = new Blob([data], { type: mimeType });
+  const link = document.createElement('a');
+  const url = URL.createObjectURL(blob);
+
+  link.setAttribute('href', url);
+  link.setAttribute('download', filename);
+  link.style.visibility = 'hidden';
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(url);
+};

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -306,6 +306,26 @@ export const api = createApi({
         };
       },
     }),
+    questionsCSV: builder.query({
+      query: ({ courseId }: { courseId: string }) => ({
+        url: `api/v1/courses/${courseId}/questions_csv.csv`,
+        method: 'GET',
+        headers: {
+          Accept: 'text/csv',
+        },
+        responseHandler: 'text',
+      }),
+      transformResponse: (response) => response,
+      transformErrorResponse: (error: ErrorResponse): { status: number; data: string[] } => {
+        const { data: { data }, status } = error;
+        const { errors } = data || {};
+
+        return {
+          status,
+          data: errors || ['Error al descargar el CSV'],
+        };
+      },
+    }),
   }),
 });
 
@@ -320,4 +340,6 @@ export const {
   useUpdateTopicMutation,
   useDeleteTopicMutation,
   useCourseReportsQuery,
+  useQuestionsCSVQuery,
+  useLazyQuestionsCSVQuery,
 } = api;


### PR DESCRIPTION
This pull request introduces functionality to export course questions as a CSV file, enhances the user interface, and adds utility functions to support file downloads. The most important changes include implementing a new API query for fetching CSV data, adding a button to trigger CSV export in the `Reports` component, and creating a utility function for downloading files.

### Feature: CSV Export for Course Questions

* **New API Query for CSV Export**: Added a `questionsCSV` query to the `api` service for fetching course questions as a CSV file. This includes handling errors and transforming responses. (`src/services/api.ts`, [src/services/api.tsR309-R328](diffhunk://#diff-0e184ea1c8a349adddc149579c2624e138ff629253721c460c28db1a33119533R309-R328))
* **Lazy Query Hook**: Introduced `useLazyQuestionsCSVQuery` for on-demand fetching of CSV data. (`src/services/api.ts`, [src/services/api.tsR343-R344](diffhunk://#diff-0e184ea1c8a349adddc149579c2624e138ff629253721c460c28db1a33119533R343-R344))

### Enhancement: User Interface Updates

* **Export Button in `Reports` Component**: Added a button to the `Reports` page for exporting course questions as a CSV file. The button displays a spinner while downloading and handles errors using toast notifications. (`src/containers/Reports.tsx`, [src/containers/Reports.tsxR83-R100](diffhunk://#diff-f8521d65bab7ce994979e267aabb89b8067974ca82f50ad8eec50549b069b2f4R83-R100))
* **CSV Download Logic**: Integrated the new CSV export functionality into the `Reports` component, including handling download progress and errors via `useEffect`. (`src/containers/Reports.tsx`, [src/containers/Reports.tsxR24-R53](diffhunk://#diff-f8521d65bab7ce994979e267aabb89b8067974ca82f50ad8eec50549b069b2f4R24-R53))

### Utility: File Download Support

* **`downloadFile` Function**: Created a reusable utility function for downloading files, supporting CSV format and customizable MIME types. (`src/lib/utils.ts`, [src/lib/utils.tsR14-R29](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224R14-R29))